### PR TITLE
feat(linux-common): accept path mappings in LC_ADDITIONAL_PATHS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install individual collections from GitHub:
 ansible-galaxy collection install git+https://github.com/NIXKnight/Ansible-Collections.git#/collections/nixknight/docker,docker-0.1.5
 
 # General collection
-ansible-galaxy collection install git+https://github.com/NIXKnight/Ansible-Collections.git#/collections/nixknight/general,general-0.1.1
+ansible-galaxy collection install git+https://github.com/NIXKnight/Ansible-Collections.git#/collections/nixknight/general,general-0.1.2
 
 # OpenTofu collection
 ansible-galaxy collection install git+https://github.com/NIXKnight/Ansible-Collections.git#/collections/nixknight/opentofu,opentofu-0.1.2

--- a/collections/nixknight/general/galaxy.yml
+++ b/collections/nixknight/general/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: "nixknight"
 name: "general"
-version: "0.1.1"
+version: "0.1.2"
 readme: "README.md"
 authors:
   - "Saad Ali <engr.saadali786@gmail.com>"

--- a/collections/nixknight/general/roles/linux-common/tasks/main.yml
+++ b/collections/nixknight/general/roles/linux-common/tasks/main.yml
@@ -80,11 +80,21 @@
     append: yes
   when: LC_SETUP_SUDO
 
+# LC_ADDITIONAL_PATHS accepts two item shapes. A bare string is a path and keeps
+# the original behaviour (recursive, ownership and mode left to the system). A
+# mapping takes `path` plus optional `owner`, `group`, `mode` and `recurse`; each
+# omitted key falls back to the module default, so the two shapes can be mixed in
+# one list. Set `recurse: false` on a directory whose contents are owned by
+# another writer (log directories, spools) so their permissions are not rewritten
+# on every run.
 - name: Create Additional Directories
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ item.path | default(item) }}"
     state: directory
-    recurse: true
+    recurse: "{{ item.recurse | default(true) | bool }}"
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    mode: "{{ item.mode | default(omit) }}"
   with_items: "{{ LC_ADDITIONAL_PATHS }}"
 
 - name: Render Misc Template File(s)


### PR DESCRIPTION
## Summary
- `LC_ADDITIONAL_PATHS` items may now be a bare path string (unchanged behaviour: recursive, ownership/mode left to the system) or a mapping `{path, owner, group, mode, recurse}`; omitted keys fall back to module defaults, so both shapes mix in one list.
- `recurse: false` keeps the contents of a directory owned by another writer (log dirs, spools) untouched on every run.
- `nixknight.general` bumped to `0.1.2`; README install line synced.

## Motivation
First consumer is the docker log directory on the AI host (`/var/log/docker`, `root:adm`, `0755`, non-recursive) that rsyslog/logrotate own.

## Validation
- `yamllint -c .yamllint` clean on the changed files (two pre-existing `truthy` warnings on 2017/2021 lines untouched).
- Both item shapes render-tested in the consuming estate playbook run (string form unchanged, mapping form applied owner/group/mode).
