### PR TITLE
fix(docker): honour no_log on docker-compose-service template items

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install individual collections from GitHub:
 
 ```bash
 # Docker collection
-ansible-galaxy collection install git+https://github.com/NIXKnight/Ansible-Collections.git#/collections/nixknight/docker,docker-0.1.5
+ansible-galaxy collection install git+https://github.com/NIXKnight/Ansible-Collections.git#/collections/nixknight/docker,docker-0.1.6
 
 # General collection
 ansible-galaxy collection install git+https://github.com/NIXKnight/Ansible-Collections.git#/collections/nixknight/general,general-0.1.1

--- a/collections/nixknight/docker/galaxy.yml
+++ b/collections/nixknight/docker/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: "nixknight"
 name: "docker"
-version: "0.1.5"
+version: "0.1.6"
 readme: "README.md"
 authors:
   - "Saad Ali <engr.saadali786@gmail.com>"

--- a/collections/nixknight/docker/roles/docker-compose-service/tasks/create_update_service.yml
+++ b/collections/nixknight/docker/roles/docker-compose-service/tasks/create_update_service.yml
@@ -87,6 +87,9 @@
     group: "{{ DOCKER_COMPOSE_SERVICE_SYSTEMD_FILE_GROUP }}"
   register: create_update_systemd_service_file
 
+# A secret-bearing template item sets `no_log: true`; that also suppresses the
+# module diff so `--diff` never prints rendered secret content. Both default to
+# false, preserving existing behavior for every non-secret template item.
 - name: Render Service Template(s)
   ansible.builtin.template:
     src: "{{ item.src }}"
@@ -96,6 +99,8 @@
     group: "{{ item.group }}"
   with_items: "{{ DOCKER_COMPOSE_SERVICE_TEMPLATES }}"
   register: render_service_templates
+  no_log: "{{ item.no_log | default(false) }}"
+  diff: "{{ not (item.no_log | default(false)) }}"
   when:
     - DOCKER_COMPOSE_SERVICE_TEMPLATES is defined
     - DOCKER_COMPOSE_SERVICE_TEMPLATES | length > 0


### PR DESCRIPTION
## Summary
- `DOCKER_COMPOSE_SERVICE_TEMPLATES` items may set `no_log: true`; the render task then suppresses its output **and** its module diff, so `--diff` never prints rendered secret content.
- Both default to `false` — every existing non-secret template item behaves exactly as before.

## Motivation
Env-file templates carrying credentials (rendered `0600`) were echoing their content in check/diff runs.

## Validation
- `yamllint -c .yamllint` clean.
- Exercised in the consuming estate: secret env templates render silently, non-secret templates still show diffs.

Version bump left to `collection-auto-versioning` (`docker-0.1.5` → `0.1.6`).
